### PR TITLE
feat: Implement light/dark mode toggle switch

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,10 +5,7 @@
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
   body {
-    background-color: #0F172A;
-    /* slate-900 */
-    color: #CBD5E1;
-    /* slate-300 */
+    @apply bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     /* Smooth scrolling for a more polished feel */
     scroll-behavior: smooth;

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -63,3 +63,6 @@ application.register('scroll-into-view', ScrollIntoViewController);
 
 import AudioFeedbackController from './audio_feedback_controller.js';
 application.register('audio-feedback', AudioFeedbackController);
+
+import ThemeController from "./theme_controller.js"
+application.register("theme", ThemeController)

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["switch"]; // Optional: if you want to change switch appearance
+
+  connect() {
+    this.applyTheme();
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'theme') {
+        this.applyTheme();
+      }
+    });
+  }
+
+  applyTheme() {
+    const theme = this.currentTheme;
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    this.updateSwitchAppearance(theme); // Optional
+    window.dispatchEvent(new CustomEvent('theme:changed', { detail: { theme } }));
+  }
+
+  toggle() {
+    const newTheme = this.currentTheme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('theme', newTheme);
+    this.applyTheme();
+  }
+
+  get currentTheme() {
+    let theme = localStorage.getItem('theme');
+    if (!theme) {
+      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return theme;
+  }
+
+  // Optional: if your switch needs to visually change
+  updateSwitchAppearance(theme) {
+    if (this.hasSwitchTarget) {
+      // Example: Add logic to change icon or text based on theme
+      // this.switchTarget.innerHTML = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+    }
+  }
+}

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -62,6 +62,11 @@
               <% end %>
               <div class="sm:hidden border-t border-slate-700 my-1"></div>
             <% end %>
+
+            <%= render 'shared/theme_toggle' %>
+
+            <div class="border-t border-slate-700 my-1"></div>
+
             <%= link_to "Logout",
               destroy_user_session_path(returnto: request.fullpath),
               method: :delete,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,9 +33,21 @@
         })(window, document, "clarity", "script", "r5h6kovuse");
       </script>
     <% end %>
+
+    <script type="text/javascript">
+      (function() {
+        const theme = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (theme === 'dark' || (!theme && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+      })();
+    </script>
   </head>
 
-  <body class="bg-gray-900">
+  <body>
     <main class="flex flex-col min-h-screen">
       <%= yield %>
     </main>

--- a/app/views/shared/_theme_toggle.html.erb
+++ b/app/views/shared/_theme_toggle.html.erb
@@ -1,0 +1,19 @@
+<div data-controller="theme">
+  <button
+    type="button"
+    data-action="click->theme#toggle"
+    data-theme-target="switch"
+    class="flex items-center justify-center w-full px-4 py-3 text-slate-200 hover:bg-slate-700 rounded-lg transition-colors duration-150"
+    aria-label="Toggle theme"
+  >
+    <!-- Sun icon for light mode, initially hidden if dark mode is active -->
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5 text-amber-400 dark:hidden">
+      <path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5h2.25a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM7.752 6.697a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z" />
+    </svg>
+    <!-- Moon icon for dark mode, initially hidden if light mode is active -->
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5 text-indigo-400 hidden dark:inline-block">
+      <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.981A10.503 10.503 0 0 1 18 19.5a10.5 10.5 0 0 1-10.5-10.5c0-2.298.552-4.457 1.528-6.431a.75.75 0 0 1 .819-.162Z" clip-rule="evenodd" />
+    </svg>
+    <span class="ml-2">Toggle Theme</span>
+  </button>
+</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './app/views/**/*.html.erb',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/components/**/*.html.erb',
+    './app/components/**/*.rb'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/aspect-ratio'),
+  ],
+}


### PR DESCRIPTION
Adds a theme toggle switch to the user profile menu, allowing you to switch between light and dark modes.

Key changes:
- Enabled Tailwind CSS dark mode via 'class' strategy.
- Created a Stimulus controller (theme_controller.js) to manage theme state, localStorage, and OS preference.
- Added an ERB partial for the toggle switch with appropriate icons.
- Integrated the toggle into the user menu in the courses index page.
- Updated global styles (application.html.erb, application.tailwind.css) to support dynamic theming and prevent FOUC.
- Registered the new Stimulus controller.